### PR TITLE
Additions to user settings & passing of mention object during custom mention event

### DIFF
--- a/jquery.mentionsInput.css
+++ b/jquery.mentionsInput.css
@@ -119,3 +119,9 @@
 .mentions-input-box .mentions > div > strong > span {
   filter: progid:DXImageTransform.Microsoft.Alpha(opacity=0);
 }
+
+.mentions-input-box .mentions-autocomplete-list.noListWrap,
+.mentions-input-box .mentions-autocomplete-list.noListWrap li {
+  width: auto;
+  white-space:nowrap;
+}


### PR DESCRIPTION
- autocompleteListDisplay: Property to allow users to set a different object property as the item to display in the mentions dropdown
- asTypeahead: Boolean that allows creation of a mentionsInput for adding a single mention without the need for a trigger (@)
- followerListSize: String allowing users to set desired size of follower list (ul) element
- followerListWrap: Boolean allowing users to set to true if no list-item wrapping is desired. ul will expand to fit all items.
- Triggering the custom mention event now sends the newly added mention object to the event handler
